### PR TITLE
bugfix: Atualiza método processar_mensagem para retornar tag e coleta estatísticas

### DIFF
--- a/app.py
+++ b/app.py
@@ -92,7 +92,7 @@ def enviar_mensagem(user_message: str, personalidade: str, chat_history, interna
     # ❌ NÃO chamamos métodos privados nem salvamos histórico aqui:
     # o próprio Chatbot já persistiu via HistoryRepo na chamada acima.
     # Task 13: Atualize stats se não interno (opcional; remova se get_stats() coleta tag/fallback)
-    # aline_bot.update_stats(is_fallback, tag)
+    aline_bot.update_stats(is_fallback, pers, tag)
 
     return chat, internal_state, ""  # limpa o input
 

--- a/core/chatbot.py
+++ b/core/chatbot.py
@@ -1,11 +1,13 @@
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Dict, Any
 import random
+from infra.repositories import StatsRepo
 
 class Chatbot:
     def __init__(self, matcher, learned_repo, history_repo, logger):
         self.matcher = matcher
         self.learned_repo = learned_repo
         self.history_repo = history_repo
+        self.stats_repo = StatsRepo('stats.json', logger=logger)
         self.logger = logger
         self.personalidade: Optional[str] = None
         self.nome_personalidade: Optional[str] = None
@@ -14,31 +16,32 @@ class Chatbot:
         self.personalidade = personalidade
         self.nome_personalidade = nome_exibicao
 
-    def processar_mensagem(self, pergunta: str, personalidade: str) -> Tuple[str, bool]:
+    def processar_mensagem(self, pergunta: str, personalidade: str) -> Tuple[str, bool, Optional[str]]:
         match = self.matcher.match(pergunta)
 
         if match is None:
             respostas_fallback = self.matcher.get_fallback_respostas(personalidade)
             resposta = random.choice(respostas_fallback) if isinstance(respostas_fallback, list) else respostas_fallback
             self.history_repo.append(pergunta, resposta, personalidade)
-            return resposta, True
+            return resposta, True, None
 
         if match["tipo"] == "intent":
             intencao = match["intencao"]
             respostas = intencao.get("respostas", {}).get(personalidade, ["Desculpe, não tenho uma resposta para essa personalidade."])
             resposta = random.choice(respostas) if isinstance(respostas, list) else respostas
+            tag = intencao.get("tag")
             self.history_repo.append(pergunta, resposta, personalidade)
-            return resposta, False
+            return resposta, False, tag
 
         if match["tipo"] == "aprendido":
             resposta = match["resposta"]
             self.history_repo.append(pergunta, resposta, personalidade)
-            return resposta, False
+            return resposta, False, None
 
         respostas_fallback = self.matcher.get_fallback_respostas(personalidade)
         resposta = random.choice(respostas_fallback) if isinstance(respostas_fallback, list) else respostas_fallback
         self.history_repo.append(pergunta, resposta, personalidade)
-        return resposta, True
+        return resposta, True, None
 
     def ensinar_nova_resposta(self, pergunta: str, resposta: str) -> bool:
         ok = self.learned_repo.append(pergunta, resposta)
@@ -49,3 +52,36 @@ class Chatbot:
 
     def carregar_historico_inicial(self, n: int = 5):
         return self.history_repo.load_last(n)
+
+    def update_stats(self, is_fallback: bool, personalidade: str, tag: Optional[str]):
+        self.stats_repo.update_interaction(is_fallback, personalidade, tag)
+
+    def get_stats(self) -> Dict[str, Any]:
+        data = self.stats_repo.load()
+        total = data["total_interactions"]
+        fallback_count = data["fallback_count"]
+        fallback_rate = fallback_count / total if total > 0 else 0.0
+
+        por_personalidade_perc = {}
+        for pers, count in data["por_personalidade"].items():
+            perc = (count / total * 100) if total > 0 else 0.0
+            por_personalidade_perc[pers] = perc
+
+        por_tag_perc = {}
+        for t, count in data["por_tag"].items():
+            perc = (count / total * 100) if total > 0 else 0.0
+            por_tag_perc[t] = perc
+
+        # Duração média: placeholder, pois não temos sessões definidas
+        media_duracao = 0.0
+
+        return {
+            "total_interactions": total,
+            "fallback_rate": fallback_rate,
+            "fallback_count": fallback_count,
+            "por_personalidade": data["por_personalidade"],
+            "por_personalidade_perc": por_personalidade_perc,
+            "por_tag": data["por_tag"],
+            "por_tag_perc": por_tag_perc,
+            "media_duracao_sessao_min": media_duracao
+        }

--- a/docs/ANALISE_ERRO_UNPACKING.md
+++ b/docs/ANALISE_ERRO_UNPACKING.md
@@ -1,0 +1,40 @@
+# Análise do Erro: ValueError - Unpacking em processar_mensagem
+
+## Descrição do Erro
+Ao executar comandos no app.py (via Gradio), ocorre o erro:
+```
+ValueError: not enough values to unpack (expected 3, got 2)
+```
+Traceback aponta para linha 80 em [`app.py`](app.py:80):
+```python
+resposta_bot, is_fallback, tag = aline_bot.processar_mensagem(user_message, pers)
+```
+
+## Causa Raiz
+- O método `processar_mensagem` em [`core/chatbot.py`](core/chatbot.py:18) retorna apenas 2 valores: `Tuple[str, bool]` (resposta, is_fallback).
+- No entanto, o unpacking espera 3 valores (resposta, is_fallback, tag).
+- Isso é uma incompatibilidade introduzida na Task 13, onde o retorno foi expandido na expectativa de propagar a tag para stats/histórico, mas o método não foi atualizado.
+
+## Evidências nos Logs
+- Log: "✅ EXATA base -> tag 'saudacao'" indica que o matcher encontrou uma intenção com tag.
+- Mas a tag não é retornada para app.py, causando falha no unpacking.
+- O matcher em [`core/intent_matcher.py`](core/intent_matcher.py:60) retorna dict com "tipo": "intent" e "intencao" (que tem "tag"), ou "aprendido" (sem tag), ou None (fallback, sem tag).
+
+## Dependências Afetadas
+- Linha 95 em app.py: `# aline_bot.update_stats(is_fallback, tag)` (comentada, mas planeja usar tag para estatísticas por tag).
+- `get_stats()` em Chatbot é chamado (linha 140), mas não implementa uso de tag ainda (código atual não mostra detalhes de stats.json).
+- Histórico é salvo sem tag explicitamente, mas poderia ser estendido.
+
+## Solução Proposta
+1. Modificar `processar_mensagem` em core/chatbot.py para retornar 3 valores:
+   - Se match["tipo"] == "intent": retornar resposta, False, match["intencao"]["tag"]
+   - Se match["tipo"] == "aprendido": retornar resposta, False, None (ou "aprendido")
+   - Se None/fallback: retornar resposta, True, None
+2. Atualizar assinatura: `-> Tuple[str, bool, Optional[str]]`
+3. Descomentar/atualizar update_stats se necessário para coletar tags.
+4. Testar com input "oi" (deve retornar tag 'saudacao', is_fallback=False).
+
+## Impacto
+- Correção mínima, cirúrgica (usar apply_diff).
+- Mantém compatibilidade com histórico existente.
+- Prepara para stats por tag em futuras tasks.

--- a/infra/repositories.py
+++ b/infra/repositories.py
@@ -81,3 +81,51 @@ class HistoryRepo(BaseRepo):
 
         historico = historico[-max_len:]  # rotação
         return self.atomic.write_json_atomic(self.path, historico, ensure_ascii=False, indent=2)
+
+class StatsRepo(BaseRepo):
+    def load(self) -> Dict[str, Any]:
+        data = self._read_json()
+        if isinstance(data, dict):
+            return data
+        return {
+            "total_interactions": 0,
+            "fallback_count": 0,
+            "por_personalidade": {},
+            "por_tag": {}
+        }
+
+    def update_interaction(self, is_fallback: bool, personalidade: str, tag: Optional[str]) -> bool:
+        if self.logger:
+            self.logger.info(f"Atualizando stats: fallback={is_fallback}, pers={personalidade}, tag={tag}")
+        data = self.load()
+        data["total_interactions"] += 1
+        if is_fallback:
+            data["fallback_count"] += 1
+        data["por_personalidade"][personalidade] = data["por_personalidade"].get(personalidade, 0) + 1
+        if tag:
+            data["por_tag"][tag] = data["por_tag"].get(tag, 0) + 1
+        success = self.atomic.write_json_atomic(self.path, data, ensure_ascii=False, indent=2)
+        if self.logger:
+            self.logger.info(f"Stats salvo: {success}")
+        return success
+class StatsRepo(BaseRepo):
+    def load(self) -> Dict[str, Any]:
+        data = self._read_json()
+        if isinstance(data, dict):
+            return data
+        return {
+            "total_interactions": 0,
+            "fallback_count": 0,
+            "por_personalidade": {},
+            "por_tag": {}
+        }
+
+    def update_interaction(self, is_fallback: bool, personalidade: str, tag: Optional[str]) -> bool:
+        data = self.load()
+        data["total_interactions"] += 1
+        if is_fallback:
+            data["fallback_count"] += 1
+        data["por_personalidade"][personalidade] = data["por_personalidade"].get(personalidade, 0) + 1
+        if tag:
+            data["por_tag"][tag] = data["por_tag"].get(tag, 0) + 1
+        return self.atomic.write_json_atomic(self.path, data, ensure_ascii=False, indent=2)


### PR DESCRIPTION
Esse pull request introduz um recurso de rastreamento de estatísticas para interações de chatbot, refatora a lógica de processamento de mensagens para propagar tags de intenção e resolve um erro de descompactação anterior. As principais alterações estão agrupadas são:

Rastreamento e relatório de estatísticas
Processamento de mensagens e propagação de intenção
Documentação e análise de erros